### PR TITLE
feat(admin): add admin initialization and user management endpoints

### DIFF
--- a/erp-admin/pom.xml
+++ b/erp-admin/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>erp-system</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>erp-admin</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>erp-common</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/erp-admin/src/main/java/com/example/Main.java
+++ b/erp-admin/src/main/java/com/example/Main.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}

--- a/erp-admin/src/main/java/com/example/erp/admin/controller/AdminController.java
+++ b/erp-admin/src/main/java/com/example/erp/admin/controller/AdminController.java
@@ -1,0 +1,29 @@
+package com.example.erp.admin.controller;
+
+import com.example.erp.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/users/{id}/block")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> blockUser(@PathVariable("id") Integer userId) {
+        adminService.blockUser(userId);
+        return ResponseEntity.ok("User blocked successfully.");
+    }
+
+    @PostMapping("/users/{id}/unblock")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> unblockUser(@PathVariable("id") Integer userId) {
+        adminService.unblockUser(userId);
+        return ResponseEntity.ok("User unblocked successfully.");
+    }
+}

--- a/erp-admin/src/main/java/com/example/erp/admin/service/AdminService.java
+++ b/erp-admin/src/main/java/com/example/erp/admin/service/AdminService.java
@@ -1,0 +1,31 @@
+package com.example.erp.admin.service;
+
+import com.example.erp.common.user.User;
+import com.example.erp.common.user.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void blockUser(Integer userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        user.setBlocked(true);
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void unblockUser(Integer userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        user.setBlocked(false);
+        userRepository.save(user);
+    }
+}

--- a/erp-auth/src/main/java/com/example/erp/auth/config/DataInitializer.java
+++ b/erp-auth/src/main/java/com/example/erp/auth/config/DataInitializer.java
@@ -1,0 +1,41 @@
+package com.example.erp.auth.config;
+
+import com.example.erp.common.user.Role;
+import com.example.erp.common.user.User;
+import com.example.erp.common.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class DataInitializer implements CommandLineRunner {
+
+    @Value("${admin.email}")
+    private String adminEmail;
+
+    @Value("${admin.password}")
+    private String adminPassword;
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+
+    @Override
+    public void run(String... args) {
+        boolean adminExists = userRepository.existsByRole(Role.ROLE_ADMIN);
+
+        if (!adminExists) {
+            User adminUser = User.builder()
+                    .email(adminEmail)
+                    .password(passwordEncoder.encode(adminPassword))
+                    .role(Role.ROLE_ADMIN)
+                    .build();
+
+            userRepository.save(adminUser);
+            System.out.println("Admin user has been created");
+        }
+    }
+}

--- a/erp-auth/src/main/java/com/example/erp/auth/controller/AuthenticationController.java
+++ b/erp-auth/src/main/java/com/example/erp/auth/controller/AuthenticationController.java
@@ -6,6 +6,7 @@ import com.example.erp.auth.service.*;
 import com.example.erp.mail.service.VerificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -25,6 +26,7 @@ public class AuthenticationController {
     private final AuthenticationService service;
 
     @PostMapping("/register")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Register a new user", description = "Registers a new user and sends a verification email")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User registered successfully"),

--- a/erp-auth/src/main/java/com/example/erp/auth/exceptions/UnauthorizedOperationException.java
+++ b/erp-auth/src/main/java/com/example/erp/auth/exceptions/UnauthorizedOperationException.java
@@ -1,0 +1,10 @@
+package com.example.erp.auth.exceptions;
+
+import com.example.erp.common.exceptions.AppException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class UnauthorizedOperationException extends AppException {
+    public UnauthorizedOperationException(String message) {super(message);}
+}

--- a/erp-common/src/main/java/com/example/erp/common/userprofile/UserProfile.java
+++ b/erp-common/src/main/java/com/example/erp/common/userprofile/UserProfile.java
@@ -50,5 +50,4 @@ public class UserProfile {
     @Enumerated(EnumType.STRING)
     @Schema(description = "Department the user belongs to", example = "HR")
     private Department department;
-
 }

--- a/erp-common/src/main/java/com/example/erp/common/userprofile/UserProfileRepository.java
+++ b/erp-common/src/main/java/com/example/erp/common/userprofile/UserProfileRepository.java
@@ -6,5 +6,4 @@ import java.util.Optional;
 
 public interface UserProfileRepository extends JpaRepository<UserProfile, Integer> {
     Optional<UserProfile> findByUserId(Integer userId);
-
 }

--- a/erp-core/pom.xml
+++ b/erp-core/pom.xml
@@ -55,5 +55,13 @@
             <version>0.0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+
+        <!-- Import erp-admin -->
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>erp-admin</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/erp-core/src/main/java/com/example/ErpSystemApplication.java
+++ b/erp-core/src/main/java/com/example/ErpSystemApplication.java
@@ -3,11 +3,10 @@ package com.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(scanBasePackages = {"com.example.erp"})
+@SpringBootApplication
 public class ErpSystemApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ErpSystemApplication.class, args);
     }
-
 }

--- a/erp-core/src/main/resources/application.properties
+++ b/erp-core/src/main/resources/application.properties
@@ -34,4 +34,6 @@ app.frontend.url=http://localhost:3000
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 spring.datasource.hikari.max-lifetime=20000
 app.base-url=http://localhost:3000
+admin.email=admin@example.com
+admin.password=admin123
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
 		<module>erp-mail</module>
 		<module>erp-common</module>
 		<module>erp-core</module>
-	</modules>
+        <module>erp-admin</module>
+    </modules>
 
 	<properties>
 		<java.version>17</java.version>
@@ -80,6 +81,12 @@
 				<version>0.11.5</version>
 				<scope>runtime</scope>
 			</dependency>
+
+				<dependency>
+					<groupId>com.example</groupId>
+					<artifactId>erp-auth</artifactId>
+					<version>0.0.1-SNAPSHOT</version>
+				</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
- Added DataInitializer (CommandLineRunner) that creates an admin user if none exists, using credentials from the admin.email and admin.password properties.

- Created a new admin module (erp-admin) with an AdminService that provides user blocking/unblocking functionality.

- Developed AdminController with endpoints (/api/admin/users/{id}/block and /unblock) secured by @PreAuthorize("hasRole('ADMIN')") to restrict access to admin users.